### PR TITLE
Support hyphens in paper/post titles

### DIFF
--- a/localtimezone.user.js
+++ b/localtimezone.user.js
@@ -44,6 +44,9 @@ function convertTime(timeStr) {
     }
 
     var origTime = moment.tz(ts2, "hh:mma", pagesTimezone);
+    if (isNaN(origTime)) {
+        return timeStr;
+    }
     var targetFormat = (use24HourFormat == true) ? "HH:mm" : "hh:mma";
     var localTime = origTime.tz(desiredTimezone).format(targetFormat);
 
@@ -63,6 +66,9 @@ function convertTimeOn24(timeStr) {
         timeStr = timeStr.replace("am", "00am").replace("pm", "00pm");
     }
     var origTime = moment.tz(timeStr, "hmma", pagesTimezone);
+    if (isNaN(origTime)) {
+        return timeStr;
+    }
     var localTime = origTime.tz(desiredTimezone).format("h:mmA");
     return localTime;
 }


### PR DESCRIPTION
Some paper/poster titles containing hyphens were wrongly converted to the user time zone, resulting in "Invalid date-Invalid date" as the title.
This pull request keeps the original text if it is not a valid date/time.